### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Methods that use seamless authentication (including `monday.api` and `monday.sto
 
 The SDK exposes the following capabilities:
 
+Only `monday.api` is available server-side
 | SDK Object | Capability |
 |--|--|
 | `monday.api` | Performing queries against the monday.com API on behalf of the connected user |


### PR DESCRIPTION
Added a line letting people know that monday.api is the only SDK capability available server side. Maybe there is a better way to show this information, but it needs to be included. Unless I am incorrect in this statement, but from my experience and experience of others, this seems to be true.