### PR TITLE
Updated setItem and getItem examples to show correct code

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ Store a value in the database:
 ```js
 monday.storage.instance.setItem('mykey', 'Lorem Ipsum').then(res => {
   console.log(res);
-}
+});
 // => { "success": true }
 ```
 
@@ -391,7 +391,7 @@ Retrieve a previously stored value in the database:
 ```js
 monday.storage.instance.getItem('mykey').then(res => {
    console.log(res.data.value);
-}
+});
 // => 'Lorem Ipsum'
 ```
 


### PR DESCRIPTION
Just adding a closing parenthesis and a semicolon for the examples for storage.setItem and storage.getItem, so the code is correct and can be copy pasted directly 