### PR TITLE
Mention "filter" in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ You can subscribe to the following types of events:
 | `'settings'` | Fired when a setting value is changed by the user |
 | `'itemIds'` | Fired when the board filter changes, which impacts the list of items currently in view |
 | `'events'` | Fired when an interaction takes place with the board/dashboard |
+| `'filter'` | Fired when the _Search_ filter changes |
 
 **Returns:**
 


### PR DESCRIPTION
The new `filter` object has been implemented in monday.com. This PR updates the README file to mention it.