### PR TITLE
Added missing types for storage.instance.deleteItem

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "monday-sdk-js",
-  "version": "0.2.0",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monday-sdk-js",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": false,
   "repository": "https://github.com/mondaycom/monday-sdk-js",
   "main": "src/index.js",

--- a/ts-tests/monday-sdk-js-module.test.ts
+++ b/ts-tests/monday-sdk-js-module.test.ts
@@ -57,8 +57,9 @@ monday.execute('closeDocModal'); // $ExpectType Promise<any>
 
 monday.oauth({ clientId: 'clientId' });
 
-monday.storage.instance.getItem('test'); // $ExpectType Promise<{ data: GetResponse; }>
+monday.storage.instance.getItem('test'); // $ExpectType Promise<GetResponse>
 monday.storage.instance.setItem('test', '123'); // $ExpectType Promise<SetResponse>
+monday.storage.instance.deleteItem('test'); // $ExpectType Promise<DeleteResponse>
 
 const mondayServer = mondaySdk({ token: '123' });
 

--- a/types/client-data.interface.ts
+++ b/types/client-data.interface.ts
@@ -8,8 +8,12 @@ interface GetResponse {
 }
 
 interface DeleteResponse {
-    success: boolean;
-    value: any;
+    method: string;
+    data: {
+        value: any; 
+        success: boolean;
+    };
+    requestId: string;
 }
 
 interface SetResponse {
@@ -68,13 +72,13 @@ export interface ClientData {
              * Returns a stored value from the database under `key`
              * @param key
              */
-            getItem(key: string): Promise<{ data: GetResponse }>;
+            getItem(key: string): Promise<GetResponse>;
 
             /**
              * Deletes a stored value from the database under `key`
              * @param key
              */
-            deleteItem(key: string): Promise<{ data: DeleteResponse }>;
+            deleteItem(key: string): Promise<DeleteResponse>;
 
             /**
              * Stores `value` under `key` in the database

--- a/types/client-data.interface.ts
+++ b/types/client-data.interface.ts
@@ -3,22 +3,39 @@ type SubscribableEvents = 'context' | 'settings' | 'itemIds' | 'events';
 type SettableTypes = 'settings';
 
 interface GetResponse {
-    value: any;
-    version: any;
+    data: {
+        success: boolean;
+        value: any;
+        version?: any;
+    };
+    errorMessage?: string | undefined;
+    method: string;
+    requestId: string;
+    type?: string | undefined;
 }
 
 interface DeleteResponse {
-    method: string;
     data: {
-        value: any; 
         success: boolean;
+        value: any; 
     };
+    errorMessage?: string | undefined;
+    method: string;
     requestId: string;
+    type?: string | undefined;
 }
 
 interface SetResponse {
-    success: boolean;
-    reason?: string | undefined;
+    data: {
+        success: boolean;
+        version: string;
+        reason?: string | undefined;
+        error?: string | undefined;
+    };
+    errorMessage?: string | undefined;
+    requestId: string;
+    method: string;
+    type?: string | undefined;
 }
 
 

--- a/types/client-data.interface.ts
+++ b/types/client-data.interface.ts
@@ -7,10 +7,16 @@ interface GetResponse {
     version: any;
 }
 
+interface DeleteResponse {
+    success: boolean;
+    value: any;
+}
+
 interface SetResponse {
     success: boolean;
     reason?: string | undefined;
 }
+
 
 export interface ClientData {
     /**
@@ -63,6 +69,12 @@ export interface ClientData {
              * @param key
              */
             getItem(key: string): Promise<{ data: GetResponse }>;
+
+            /**
+             * Deletes a stored value from the database under `key`
+             * @param key
+             */
+            deleteItem(key: string): Promise<{ data: DeleteResponse }>;
 
             /**
              * Stores `value` under `key` in the database


### PR DESCRIPTION
The types should be updated now according to the docs.
Closes #84.