### PR TITLE
Add missing TypeScript types for apiVersion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "monday-sdk-js",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "monday-sdk-js",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monday-sdk-js",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": false,
   "repository": "https://github.com/mondaycom/monday-sdk-js",
   "main": "src/index.js",

--- a/ts-tests/monday-sdk-js-module.test.ts
+++ b/ts-tests/monday-sdk-js-module.test.ts
@@ -3,6 +3,8 @@ const monday = mondaySdk();
 
 monday.api('test'); // $ExpectType Promise<{ data: object; }>
 
+monday.setApiVersion('2023-10'); // $ExpectType void
+mondaySdk({ apiVersion: '2023-10' });
 monday.api('test', { apiVersion: '2023-07' }); // $ExpectType Promise<{ data: object; }>
 
 monday.setToken('test'); // $ExpectType void
@@ -63,9 +65,10 @@ monday.storage.instance.getItem('test'); // $ExpectType Promise<GetResponse>
 monday.storage.instance.setItem('test', '123'); // $ExpectType Promise<SetResponse>
 monday.storage.instance.deleteItem('test'); // $ExpectType Promise<DeleteResponse>
 
-const mondayServer = mondaySdk({ token: '123' });
+const mondayServer = mondaySdk({ token: '123', apiVersion: '2023-10' });
 
 mondayServer.setToken('123'); // $ExpectType void
+mondayServer.setApiVersion('2023-10'); // $ExpectType void
 mondayServer.api('test'); // $ExpectType Promise<any>
 mondayServer.api('test', { token: 'test' }); // $ExpectType Promise<any>
 mondayServer.api('test', { variables: { variable1: 'test' } }); // $ExpectType Promise<any>

--- a/types/client-api.interface.ts
+++ b/types/client-api.interface.ts
@@ -1,4 +1,4 @@
-interface APIOptions {
+export interface APIOptions {
     /**
      * Access token for the API
      * If not set, will use the credentials of the current user (client only)
@@ -12,9 +12,9 @@ interface APIOptions {
 
     /**
      * A string specifying which version of the API should be used
-     * If not set, will use the default version (stable)
+     * If not set, will use the current API version
      */
-    apiVersion?: string;
+    apiVersion?: string | undefined;
 }
 
 interface OAuthOptions {
@@ -45,6 +45,12 @@ export interface ClientApi {
      * @param token Access token for the API
      */
     setToken(token: string): void;
+
+    /**
+     * Allows to set the API version for future requests.
+     * @param version A string specifying which version of the API should be used 
+     */ 
+    setApiVersion(version: string): void;
 
     /**
      * Performs a client-side redirection of the user to the monday OAuth screen with your client ID embedded in the URL,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
 // Original Definitions were contributed by: Josh Parnham <https://github.com/josh->
 import { ClientData } from './client-data.interface';
 import { ClientExecute } from './client-execute.interface';
-import { ClientApi } from './client-api.interface';
+import { ClientApi, APIOptions } from './client-api.interface';
 
 export as namespace mondaySdk;
 
@@ -10,7 +10,9 @@ type MondayClientSdk = ClientData & ClientExecute & ClientApi;
 interface MondayServerSdk {
     setToken(token: string): void;
 
-    api(query: string, options?: Partial<{ token: string, variables: object, apiVersion: string } >): Promise<any>;
+    setApiVersion(version: string): void;
+
+    api(query: string, options?: APIOptions): Promise<any>;
 
     oauthToken(code: string, clientId: string, clientSecret: string): Promise<any>;
 }
@@ -19,12 +21,14 @@ declare function init(
     config?: Partial<{
         clientId: string;
         apiToken: string;
+        apiVersion: string;
     }>,
 ): MondayClientSdk;
 
 declare function init(
     config?: Partial<{
         token: string;
+        apiVersion: string;
     }>,
 ): MondayServerSdk;
 


### PR DESCRIPTION
This PR adds missing TypeScript types for apiVersion/setApiVersion.