### PR TITLE
Add missing apiVersion property

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -69,7 +69,7 @@ class MondayClientSdk {
       return mondayApiClient.execute(params, token, { apiVersion });
     } else {
       return new Promise((resolve, reject) => {
-        this._localApi("api", { params })
+        this._localApi("api", { params, apiVersion })
           .then(result => {
             resolve(result.data);
           })


### PR DESCRIPTION
This change will enable changing the API version when using the SDK in a view. The TS types are already in place, so I guess this is a bugfix, not a new feature.