### PR TITLE
Constants not loaded correctly when NODE_ENV set to "development" (#115)

### DIFF
--- a/src/constants-test.js
+++ b/src/constants-test.js
@@ -5,10 +5,12 @@ describe("constants", () => {
   //setup
   beforeEach(() => {
     process.env.NODE_ENV = "development";
-    process.env.MONDAY_COM_PROTOCOL = undefined;
-    process.env.MONDAY_COM_DOMAIN = undefined;
-    process.env.MONDAY_SUBDOMAIN_API = undefined;
-    process.env.MONDAY_OAUTH_SUBDOMAIN = undefined;
+    // Using `process.env.VARIABLE = undefined` becomes an "undefined" string instead of actual undefined variable
+    // delete makes sure the variable does not exist and thus is undefined.
+    delete process.env.MONDAY_COM_PROTOCOL;
+    delete process.env.MONDAY_COM_DOMAIN;
+    delete process.env.MONDAY_SUBDOMAIN_API;
+    delete process.env.MONDAY_OAUTH_SUBDOMAIN;
   });
 
   it("should have at least 3 constants", () => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,7 +7,7 @@ function isNodeDevStageEnv() {
 }
 
 const getEnvOrDefault = (key, defaultVal) => {
-  return isNodeDevStageEnv() && process.env[key] !== "undefined" ? process.env[key] : defaultVal;
+  return isNodeDevStageEnv() && typeof process.env[key] !== "undefined" ? process.env[key] : defaultVal;
 };
 
 const MONDAY_PROTOCOL = () => getEnvOrDefault("MONDAY_COM_PROTOCOL", "https");


### PR DESCRIPTION
Assigning `process.env.VARIABLE = undefined` actually does `process.env.VARIABLE = "undefined"` (I haven't investigated why). This lead to the `constants-test.js` test to wrongfully test the use-case when an environment variable is undefined. I switched it up to `delete process.env.VARIABLE` which properly leaves the property `undefined`.