### PR TITLE
fix: api method type

### DIFF
--- a/types/client-api.interface.ts
+++ b/types/client-api.interface.ts
@@ -38,7 +38,7 @@ export interface ClientApi {
      * Placeholders may be used, which will be substituted by the variables object passed within the options.
      * @param options
      */
-    api(query: string, options?: APIOptions): Promise<{ data: object }>;
+    api<T = any>(query: string, options?: APIOptions): Promise<{ data: T, account_id: number }>;
 
     /**
      * Instead of passing the API token to the `api()` method on each request, you can set the API token once using:

--- a/types/server-sdk.interface.ts
+++ b/types/server-sdk.interface.ts
@@ -5,7 +5,7 @@ export interface MondayServerSdk {
 
     setApiVersion(version: string): void;
 
-    api(query: string, options?: APIOptions): Promise<any>;
+    api<T = any>(query: string, options?: APIOptions): Promise<T>;
 
     oauthToken(code: string, clientId: string, clientSecret: string): Promise<any>;
 }


### PR DESCRIPTION
## Description

The goal is to have the type of the api method set as a generic type so that the users can propagate the response type of the executed query.

The changes are done to be backwards compatible, so the generic type is defaulted to `any`.

In addition add the `account_id` in the response type, as it is shown to be the case.

<img width="554" alt="image" src="https://github.com/mondaycom/monday-sdk-js/assets/31168388/14c46640-0851-4d7c-b2a4-ae7b02dfe2af">
