### PR TITLE
Add return typedef for MondayClientSdk#listen

### DIFF
--- a/types/client-data.interface.ts
+++ b/types/client-data.interface.ts
@@ -78,6 +78,7 @@ export interface ClientData {
    * @param typeOrTypes The type, or array of types, of events to subscribe to
    * @param callback A callback function that is fired when the listener is triggered by a client-side event
    * @param params Reserved for future use
+   * @return Unsubscribe/unlisten from all added during this method call
    */
   listen<
     CustomResponse,
@@ -87,7 +88,7 @@ export interface ClientData {
     typeOrTypes: T | ReadonlyArray<T>,
     callback: (res: { data: SubscribableEventsResponse<AppFeatureType>[T] & CustomResponse }) => void,
     params?: object & { appFeatureType?: AppFeatureType }
-  ): void;
+  ): () => void;
 
   /**
    * Set data in your application, such as updating settings


### PR DESCRIPTION
MondayClientSdk#listen has a void return type in [types/client-data.interface.ts](https://github.com/mondaycom/monday-sdk-js/blob/96bc10a7d31bacf427c7c7fdd082e83ff097161f/types/client-data.interface.ts#L82) but returns an unlisten function in [src/client.js](https://github.com/mondaycom/monday-sdk-js/blob/96bc10a7d31bacf427c7c7fdd082e83ff097161f/src/client.js#L88).

This change fixes that and adds JSDoc explaining it