### PR TITLE
fix(types): Add GraphQL APIError interface for better error handling

### DIFF
--- a/types/client-api.interface.ts
+++ b/types/client-api.interface.ts
@@ -30,7 +30,7 @@ interface OAuthOptions {
     mondayOauthUrl?: string | undefined;
 }
 
-interface APIError {
+export interface APIError {
     /**
      * The error message describing what went wrong
      */

--- a/types/client-api.interface.ts
+++ b/types/client-api.interface.ts
@@ -79,7 +79,7 @@ export interface ClientApi {
      * Placeholders may be used, which will be substituted by the variables object passed within the options.
      * @param options
      */
-    api<T = any>(query: string, options?: APIOptions): Promise<{ data: T, account_id: number, errors?: APIError[] }>;
+    api<T = any>(query: string, options?: APIOptions): Promise<{ data?: T, account_id?: number, errors?: APIError[] }>;
 
     /**
      * Instead of passing the API token to the `api()` method on each request, you can set the API token once using:

--- a/types/client-api.interface.ts
+++ b/types/client-api.interface.ts
@@ -30,6 +30,47 @@ interface OAuthOptions {
     mondayOauthUrl?: string | undefined;
 }
 
+interface APIError {
+    /**
+     * The error message describing what went wrong
+     */
+    message: string;
+    
+    /**
+     * Source locations in the GraphQL query document which correspond to this error
+     */
+    locations?: {
+        /**
+         * The line number in the GraphQL query where the error occurred
+         */
+        line?: number;
+        /**
+         * The column number in the GraphQL query where the error occurred
+         */
+        column?: number;
+    }[];
+
+    path?: string[];
+
+    /**
+     * Additional error metadata and extensions
+     */
+    extensions?: {
+        /**
+         * Error code identifying the type of error
+         */
+        code?: string;
+        /**
+         * Additional error-specific data
+         */
+        error_data?: object;
+        /**
+         * HTTP status code associated with the error
+         */
+        status_code?: number;
+    };
+}
+    
 export interface ClientApi {
     /**
      * Used for querying the monday.com GraphQL API seamlessly on behalf of the connected user, or using a provided API token.
@@ -38,7 +79,7 @@ export interface ClientApi {
      * Placeholders may be used, which will be substituted by the variables object passed within the options.
      * @param options
      */
-    api<T = any>(query: string, options?: APIOptions): Promise<{ data: T, account_id: number }>;
+    api<T = any>(query: string, options?: APIOptions): Promise<{ data: T, account_id: number, errors?: APIError[] }>;
 
     /**
      * Instead of passing the API token to the `api()` method on each request, you can set the API token once using:


### PR DESCRIPTION
Based on the documentation found here: https://developer.monday.com/api-reference/changelog/breaking-change-consistent-error-format

I extended types to include the error object that could be returned by the `api` function. This provides proper TypeScript typing for error responses, improving type safety and developer experience when handling API errors.

Linked Github Issue: https://github.com/mondaycom/monday-sdk-js/issues/147