### PR TITLE
Enhance context with AppSubscription type definition

### DIFF
--- a/ts-tests/monday-sdk-js-module.test.ts
+++ b/ts-tests/monday-sdk-js-module.test.ts
@@ -13,8 +13,26 @@ monday.get("context", { appFeatureType: "AppFeatureBoardView" }).then(res => {
   const { data }: { data: { app: { id: number }; theme: string; boardId: number; viewMode: string } } = res;
 });
 
-monday.get<{ id: number, name: string }>("testString").then(res => {
-  const { data }: { data: { id: number, name: string } } = res;
+monday.get("context").then(res => {
+  const {
+    data
+  }: {
+    data: {
+      subscription?: {
+        billing_period: string;
+        days_left: number;
+        is_trial: boolean;
+        max_units: number | null;
+        plan_id: string;
+        pricing_version: number;
+        renewal_date: string;
+      };
+    };
+  } = res;
+});
+
+monday.get<{ id: number; name: string }>("testString").then(res => {
+  const { data }: { data: { id: number; name: string } } = res;
 });
 
 monday.get<{ text: string; level: number }>("settings").then(res => {

--- a/types/client-context.type.ts
+++ b/types/client-context.type.ts
@@ -37,6 +37,37 @@ export type Permissions = {
   requiredScopes: string[];
 };
 
+export type AppSubscription = {
+  /**
+   * The billing period frequency: monthly or yearly
+   */
+  billing_period: "yearly" | "monthly";
+  /**
+   * The number of days left until the subscription ends
+   */
+  days_left: number;
+  /**
+   * Returns true if it is still a trial subscription
+   */
+  is_trial: boolean;
+  /**
+   * The maximum number of seats allowed for seat-based plans. Returns null for feature-based plans
+   */
+  max_units: number | null;
+  /**
+   * The subscription plan ID from the app's side
+   */
+  plan_id: string;
+  /**
+   * The subscription's pricing version.
+   */
+  pricing_version: number;
+  /**
+   * The date when the subscription renews, in ISO 8601 format
+   */
+  renewal_date: string;
+};
+
 export type BaseContext = {
   themeConfig?: Theme;
   theme: string;
@@ -46,6 +77,7 @@ export type BaseContext = {
   app: App;
   appVersion: AppVersion;
   permissions: Permissions;
+  subscription?: AppSubscription;
 };
 
 export type AppFeatureBoardViewContext = BaseContext & {

--- a/types/client-context.type.ts
+++ b/types/client-context.type.ts
@@ -59,7 +59,7 @@ export type AppSubscription = {
    */
   plan_id: string;
   /**
-   * The subscription's pricing version.
+   * The subscription's pricing version
    */
   pricing_version: number;
   /**


### PR DESCRIPTION
* Introduced AppSubscription type to define subscription properties in client context which are currently present, but not typed.
* Updated test cases to include subscription details in context response.

Example usage:

<img width="833" alt="image" src="https://github.com/user-attachments/assets/1d9d3341-267f-475b-8779-d7ede3472869" />

