### PR TITLE
Add typed operations layer with Jest tests

### DIFF
--- a/__tests__/operations/boards/getBoards.test.ts
+++ b/__tests__/operations/boards/getBoards.test.ts
@@ -1,0 +1,17 @@
+import { getBoards } from '../../../src/operations/boards/getBoards';
+import { OperationsError } from '../../../src/operations/errors';
+
+const queryRegex = /query \(\$ids: \[Int\]\)/;
+
+describe('getBoards', () => {
+  it('calls api with correct query and variables', async () => {
+    const api = jest.fn().mockResolvedValue({ boards: [{ id: 1, name: 'b' }] });
+    await getBoards(api, { ids: [1] });
+    expect(api).toHaveBeenCalledWith(expect.stringMatching(queryRegex), { variables: { ids: [1] } });
+  });
+
+  it('throws OperationsError on rejection', async () => {
+    const api = jest.fn().mockRejectedValue(new Error('fail'));
+    await expect(getBoards(api)).rejects.toBeInstanceOf(OperationsError);
+  });
+});

--- a/__tests__/operations/items/changeColumnValue.test.ts
+++ b/__tests__/operations/items/changeColumnValue.test.ts
@@ -1,0 +1,17 @@
+import { changeColumnValue } from '../../../src/operations/items/changeColumnValue';
+import { OperationsError } from '../../../src/operations/errors';
+
+describe('changeColumnValue', () => {
+  it('sends correct mutation with variables', async () => {
+    const api = jest.fn().mockResolvedValue({ change_column_value: { id: 3 } });
+    await changeColumnValue(api, 1, 'text', 'val');
+    expect(api).toHaveBeenCalledWith(expect.stringContaining('change_column_value'), {
+      variables: { itemId: 1, columnId: 'text', value: 'val' },
+    });
+  });
+
+  it('throws OperationsError on rejection', async () => {
+    const api = jest.fn().mockRejectedValue(new Error('fail'));
+    await expect(changeColumnValue(api, 1, 'c', 'v')).rejects.toBeInstanceOf(OperationsError);
+  });
+});

--- a/__tests__/operations/items/createItem.test.ts
+++ b/__tests__/operations/items/createItem.test.ts
@@ -1,0 +1,22 @@
+import { createItem } from '../../../src/operations/items/createItem';
+import { OperationsError } from '../../../src/operations/errors';
+
+describe('createItem', () => {
+  it('sends correct mutation and variables', async () => {
+    const api = jest.fn().mockResolvedValue({ create_item: { id: 1 } });
+    await createItem(api, 1, 'g1', 'Item', { text: 't' });
+    expect(api).toHaveBeenCalledWith(expect.stringContaining('mutation'), {
+      variables: {
+        boardId: 1,
+        groupId: 'g1',
+        itemName: 'Item',
+        columnValues: JSON.stringify({ text: 't' }),
+      },
+    });
+  });
+
+  it('throws OperationsError on failure', async () => {
+    const api = jest.fn().mockRejectedValue(new Error('err'));
+    await expect(createItem(api, 1, undefined, 'name')).rejects.toBeInstanceOf(OperationsError);
+  });
+});

--- a/__tests__/operations/items/getItemsByQuery.test.ts
+++ b/__tests__/operations/items/getItemsByQuery.test.ts
@@ -1,0 +1,17 @@
+import { getItemsByQuery } from '../../../src/operations/items/getItemsByQuery';
+import { OperationsError } from '../../../src/operations/errors';
+
+describe('getItemsByQuery', () => {
+  it('passes correct query and variables', async () => {
+    const api = jest.fn().mockResolvedValue({ items_page_by_column_values: [] });
+    await getItemsByQuery(api, 1, { columnId: 'status', columnValue: 'done' });
+    expect(api).toHaveBeenCalledWith(expect.stringContaining('items_page_by_column_values'), {
+      variables: { boardId: 1, columnId: 'status', columnValue: 'done', limit: undefined, page: undefined },
+    });
+  });
+
+  it('throws OperationsError on failure', async () => {
+    const api = jest.fn().mockRejectedValue(new Error('oops'));
+    await expect(getItemsByQuery(api, 1, { columnId: 'c', columnValue: 'v' })).rejects.toBeInstanceOf(OperationsError);
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/__tests__/operations'],
+  collectCoverage: true,
+  collectCoverageFrom: ['src/operations/**/*.ts'],
+};

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "sinon": "^9.0.0",
     "sinon-chai": "^3.5.0",
     "typescript": "^4.9.5",
+    "@types/jest": "^29.5.3",
+    "jest": "^29.6.1",
+    "ts-jest": "^29.1.1",
     "webpack": "^4.38.0",
     "webpack-cli": "^3.3.6",
     "webpack-dev-server": "^3.7.2"
@@ -42,7 +45,7 @@
   "scripts": {
     "start": "webpack-dev-server",
     "build": "webpack --mode=production --env.WEBPACK_BUILD=true",
-    "test": "mocha './src/**/*-test.js'",
+    "test": "mocha './src/**/*-test.js' && jest",
     "test:watch": "mocha './src/**/*-test.js' --watch",
     "precommit": "yarn lint && yarn style-check",
     "lint": "eslint './src/**/*.*'",

--- a/src/operations/README.md
+++ b/src/operations/README.md
@@ -1,0 +1,12 @@
+# Operations Layer
+
+This directory contains high level wrappers around `api()`.
+
+## Adding a new helper
+
+1. Create a new `.ts` file under the relevant resource folder (e.g. `boards/`).
+2. Export your function and any public types from that file.
+3. Re-export the helper in `operationsClient.ts` so consumers can use it through the factory.
+
+Helpers should accept an `api` function as the first argument and return typed
+results. See existing files for examples.

--- a/src/operations/boards/getBoards.ts
+++ b/src/operations/boards/getBoards.ts
@@ -1,0 +1,36 @@
+import { OperationsError } from '../errors';
+import { ApiFunction } from '../operationsClient';
+
+export interface Board {
+  id: number;
+  name: string;
+}
+
+export interface GetBoardsOptions {
+  ids?: number[];
+}
+
+export interface GetBoardsResponse {
+  boards: Board[];
+}
+
+export async function getBoards(
+  api: ApiFunction,
+  options: GetBoardsOptions = {}
+): Promise<GetBoardsResponse> {
+  const query = `
+    query ($ids: [Int]) {
+      boards(ids: $ids) {
+        id
+        name
+      }
+    }
+  `;
+
+  try {
+    const result = await api<{ boards: Board[] }>(query, { variables: { ids: options.ids } });
+    return { boards: result.boards };
+  } catch (err) {
+    throw new OperationsError((err as Error).message);
+  }
+}

--- a/src/operations/errors.ts
+++ b/src/operations/errors.ts
@@ -1,0 +1,6 @@
+export class OperationsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OperationsError';
+  }
+}

--- a/src/operations/items/changeColumnValue.ts
+++ b/src/operations/items/changeColumnValue.ts
@@ -1,0 +1,36 @@
+import { OperationsError } from '../errors';
+import { ApiFunction } from '../operationsClient';
+
+export interface ChangeColumnValueResponse {
+  id: number;
+}
+
+export type ColumnValue = string | Record<string, unknown>;
+
+export async function changeColumnValue(
+  api: ApiFunction,
+  itemId: number,
+  columnId: string,
+  value: ColumnValue
+): Promise<ChangeColumnValueResponse> {
+  const query = `
+    mutation ($itemId: Int!, $columnId: String!, $value: JSON!) {
+      change_column_value(item_id: $itemId, column_id: $columnId, value: $value) {
+        id
+      }
+    }
+  `;
+
+  const variables = {
+    itemId,
+    columnId,
+    value: typeof value === 'object' ? JSON.stringify(value) : value,
+  };
+
+  try {
+    const result = await api<{ change_column_value: { id: number } }>(query, { variables });
+    return { id: result.change_column_value.id };
+  } catch (err) {
+    throw new OperationsError((err as Error).message);
+  }
+}

--- a/src/operations/items/createItem.ts
+++ b/src/operations/items/createItem.ts
@@ -1,0 +1,38 @@
+import { OperationsError } from '../errors';
+import { ApiFunction } from '../operationsClient';
+
+export interface CreateItemResponse {
+  id: number;
+}
+
+export type ColumnValues = string | Record<string, unknown>;
+
+export async function createItem(
+  api: ApiFunction,
+  boardId: number,
+  groupId: string | undefined,
+  itemName: string,
+  columnValues?: ColumnValues
+): Promise<CreateItemResponse> {
+  const query = `
+    mutation ($boardId: Int!, $groupId: String, $itemName: String!, $columnValues: JSON) {
+      create_item(board_id: $boardId, group_id: $groupId, item_name: $itemName, column_values: $columnValues) {
+        id
+      }
+    }
+  `;
+
+  const variables = {
+    boardId,
+    groupId,
+    itemName,
+    columnValues: typeof columnValues === 'object' ? JSON.stringify(columnValues) : columnValues,
+  };
+
+  try {
+    const result = await api<{ create_item: { id: number } }>(query, { variables });
+    return { id: result.create_item.id };
+  } catch (err) {
+    throw new OperationsError((err as Error).message);
+  }
+}

--- a/src/operations/items/getItemsByQuery.ts
+++ b/src/operations/items/getItemsByQuery.ts
@@ -1,0 +1,53 @@
+import { OperationsError } from '../errors';
+import { ApiFunction } from '../operationsClient';
+
+export interface Item {
+  id: number;
+  name: string;
+}
+
+export interface ItemsQuery {
+  columnId: string;
+  columnValue: string | number;
+  limit?: number;
+  page?: number;
+}
+
+export interface GetItemsByQueryOptions {
+  fields?: string[];
+}
+
+export interface GetItemsByQueryResponse {
+  items: Item[];
+}
+
+export async function getItemsByQuery(
+  api: ApiFunction,
+  boardId: number,
+  queryInput: ItemsQuery,
+  options: GetItemsByQueryOptions = {}
+): Promise<GetItemsByQueryResponse> {
+  const fields = options.fields?.join(' ') || 'id name';
+  const query = `
+    query ($boardId: Int!, $columnId: String!, $columnValue: String!, $limit: Int, $page: Int) {
+      items_page_by_column_values(board_id: $boardId, column_id: $columnId, column_value: $columnValue, limit: $limit, page: $page) {
+        ${fields}
+      }
+    }
+  `;
+
+  const variables = {
+    boardId,
+    columnId: queryInput.columnId,
+    columnValue: String(queryInput.columnValue),
+    limit: queryInput.limit,
+    page: queryInput.page,
+  };
+
+  try {
+    const result = await api<{ items_page_by_column_values: Item[] }>(query, { variables });
+    return { items: result.items_page_by_column_values };
+  } catch (err) {
+    throw new OperationsError((err as Error).message);
+  }
+}

--- a/src/operations/operationsClient.ts
+++ b/src/operations/operationsClient.ts
@@ -1,0 +1,26 @@
+import { getBoards } from './boards/getBoards';
+import { getItemsByQuery } from './items/getItemsByQuery';
+import { createItem } from './items/createItem';
+import { changeColumnValue } from './items/changeColumnValue';
+
+export interface ApiFunction {
+  <T = any>(query: string, options?: { variables?: object }): Promise<T>;
+}
+
+export { getBoards, getItemsByQuery, createItem, changeColumnValue };
+
+export interface OperationsClient {
+  getBoards: typeof getBoards;
+  getItemsByQuery: typeof getItemsByQuery;
+  createItem: typeof createItem;
+  changeColumnValue: typeof changeColumnValue;
+}
+
+export function createOperationsClient(api: ApiFunction): OperationsClient {
+  return {
+    getBoards: (options) => getBoards(api, options),
+    getItemsByQuery: (boardId, query, options) => getItemsByQuery(api, boardId, query, options),
+    createItem: (boardId, groupId, itemName, columnValues) => createItem(api, boardId, groupId, itemName, columnValues),
+    changeColumnValue: (itemId, columnId, value) => changeColumnValue(api, itemId, columnId, value),
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,20 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": [
-            "es6"
-        ],
+        "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "noEmit": true,
         "forceConsistentCasingInFileNames": true,
-        "esModuleInterop": true
+        "esModuleInterop": true,
+        "types": ["jest"]
     },
-    "files": [
-        "types/index.d.ts",
-        "ts-tests/monday-sdk-js-module.test.ts"
+    "include": [
+        "types/**/*.ts",
+        "ts-tests/**/*.ts",
+        "src/operations/**/*.ts",
+        "__tests__/operations/**/*.ts"
     ]
 }


### PR DESCRIPTION
## Summary
- add operations layer with helper functions around `api()`
- provide operations client factory
- document extensibility of operations layer
- add jest tests for operations
- configure ts-jest and update dev dependencies
- include new sources in tsconfig

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'jest')*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_6849c3fdfc98833297083e579ec2ebc6