### PR TITLE
Add typed board and item APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,28 @@ import mondaySdk from "monday-sdk-js";
 const monday = mondaySdk();
 ```
 
+Example usage with the new boards and items APIs:
+
+```ts
+await monday.boards.createBoard({ name: "New board", kind: "private" });
+const board = await monday.boards.getBoard({ boardId: 123456 });
+
+await monday.items.createItem({ boardId: 123456, name: "Task" });
+const item = await monday.items.getItem({ itemId: 987654 });
+
+const page1 = await monday.items.listBoardItems({
+  boardId: 123456,
+  limit: 50,
+  queryParams: {
+    operator: "and",
+    rules: [
+      { columnId: "status", compareValue: [1] },
+      { columnId: "people", compareValue: ["person-87654321"], operator: "any_of" }
+    ]
+  }
+});
+```
+
 
 ### As a `<script>` tag directly in your HTML code
 You can also load the SDK directly into your HTML code by adding:

--- a/src/boards-sdk/boards-api-test.js
+++ b/src/boards-sdk/boards-api-test.js
@@ -1,0 +1,52 @@
+const { sinon, assert, expect } = require("../tests/helpers");
+const fetch = require("../monday-api-client/fetch");
+const createBoardsApi = require("./boards-api");
+
+describe("boards api", () => {
+  let fetchStub;
+  let boards;
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(fetch, "nodeFetch").resolves({
+      json: async () => ({ data: { create_board: { id: 1, name: "b", board_kind: "private" } } }),
+      headers: { get: () => "application/json" }
+    });
+    boards = createBoardsApi({ _token: "token" });
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+  });
+
+  it("createBoard should send mutation", async () => {
+    const res = await boards.createBoard({ name: "b", kind: "private" });
+    assert.calledOnce(fetchStub);
+    const body = fetchStub.firstCall.args[1].body;
+    assert.include(body, "create_board");
+    assert.include(body, "board_name");
+    expect(res).to.deep.equal({ id: 1, name: "b", board_kind: "private" });
+  });
+
+  it("getBoard should query board", async () => {
+    fetchStub.resolves({
+      json: async () => ({ data: { boards: [{ id: 2, name: "brd" }] } }),
+      headers: { get: () => "application/json" }
+    });
+    const res = await boards.getBoard({ boardId: 2 });
+    const body = fetchStub.firstCall.args[1].body;
+    assert.include(body, "boards");
+    assert.include(body, "ids");
+    expect(res).to.deep.equal({ id: 2, name: "brd" });
+  });
+
+  it("archiveBoard should send mutation", async () => {
+    fetchStub.resolves({
+      json: async () => ({ data: { archive_board: { id: 3, state: "archived" } } }),
+      headers: { get: () => "application/json" }
+    });
+    const res = await boards.archiveBoard({ boardId: 3 });
+    const body = fetchStub.firstCall.args[1].body;
+    assert.include(body, "archive_board");
+    expect(res).to.deep.equal({ id: 3, state: "archived" });
+  });
+});

--- a/src/boards-sdk/boards-api.js
+++ b/src/boards-sdk/boards-api.js
@@ -1,0 +1,36 @@
+const { execute } = require("../monday-api-client/monday-api-client");
+const { logWarnings } = require("../helpers/monday-api-helpers");
+
+const TOKEN_MISSING_ERROR = "Should send 'token' as an option or call mondaySdk.setToken(TOKEN)";
+
+function callExecute(sdk, query, variables, apiVersion) {
+  const token = sdk._token || sdk._apiToken;
+  if (!token) throw new Error(TOKEN_MISSING_ERROR);
+  const version = apiVersion || sdk._apiVersion;
+  return execute({ query, variables }, token, { apiVersion: version }).then(logWarnings);
+}
+
+module.exports = function boardsApi(sdk) {
+  return {
+    async createBoard({ name, kind }, apiVersion) {
+      const query = `mutation ($name: String!, $kind: BoardKind) {\n  create_board(board_name: $name, board_kind: $kind) { id name board_kind }\n}`;
+      const variables = { name, kind };
+      const result = await callExecute(sdk, query, variables, apiVersion);
+      return result.data.create_board;
+    },
+
+    async getBoard({ boardId }, apiVersion) {
+      const query = `query ($boardId: Int!) {\n  boards(ids: [$boardId]) { id name board_kind state }\n}`;
+      const variables = { boardId };
+      const result = await callExecute(sdk, query, variables, apiVersion);
+      return result.data.boards[0];
+    },
+
+    async archiveBoard({ boardId }, apiVersion) {
+      const query = `mutation ($boardId: Int!) {\n  archive_board(board_id: $boardId) { id state }\n}`;
+      const variables = { boardId };
+      const result = await callExecute(sdk, query, variables, apiVersion);
+      return result.data.archive_board;
+    }
+  };
+};

--- a/src/boards-sdk/items-api-test.js
+++ b/src/boards-sdk/items-api-test.js
@@ -1,0 +1,61 @@
+const { sinon, assert, expect } = require("../tests/helpers");
+const fetch = require("../monday-api-client/fetch");
+const createItemsApi = require("./items-api");
+
+describe("items api", () => {
+  let fetchStub;
+  let items;
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(fetch, "nodeFetch").resolves({
+      json: async () => ({ data: { create_item: { id: 1, name: "it" } } }),
+      headers: { get: () => "application/json" }
+    });
+    items = createItemsApi({ _token: "token" });
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+  });
+
+  it("createItem should send mutation", async () => {
+    const res = await items.createItem({ boardId: 1, name: "it" });
+    assert.calledOnce(fetchStub);
+    const body = fetchStub.firstCall.args[1].body;
+    assert.include(body, "create_item");
+    expect(res).to.deep.equal({ id: 1, name: "it" });
+  });
+
+  it("getItem should query item", async () => {
+    fetchStub.resolves({
+      json: async () => ({ data: { items: [{ id: 2, name: "it2" }] } }),
+      headers: { get: () => "application/json" }
+    });
+    const res = await items.getItem({ itemId: 2 });
+    const body = fetchStub.firstCall.args[1].body;
+    assert.include(body, "items");
+    expect(res).to.deep.equal({ id: 2, name: "it2" });
+  });
+
+  it("listBoardItems should use items_page", async () => {
+    fetchStub.resolves({
+      json: async () => ({ data: { boards: [{ items_page: { cursor: "c1", items: [] } }] } }),
+      headers: { get: () => "application/json" }
+    });
+    await items.listBoardItems({ boardId: 1, limit: 50, queryParams: { rules: [] } });
+    const body = fetchStub.firstCall.args[1].body;
+    assert.include(body, "items_page");
+    assert.include(body, "limit");
+    assert.include(body, "query_params");
+  });
+
+  it("listBoardItems should use next_items_page", async () => {
+    fetchStub.resolves({
+      json: async () => ({ data: { boards: [{ next_items_page: { cursor: null, items: [] } }] } }),
+      headers: { get: () => "application/json" }
+    });
+    await items.listBoardItems({ boardId: 1, cursor: "c1" });
+    const body = fetchStub.firstCall.args[1].body;
+    assert.include(body, "next_items_page");
+  });
+});

--- a/src/boards-sdk/items-api.js
+++ b/src/boards-sdk/items-api.js
@@ -1,0 +1,55 @@
+const { execute } = require("../monday-api-client/monday-api-client");
+const { logWarnings } = require("../helpers/monday-api-helpers");
+
+const TOKEN_MISSING_ERROR = "Should send 'token' as an option or call mondaySdk.setToken(TOKEN)";
+
+function callExecute(sdk, query, variables, apiVersion) {
+  const token = sdk._token || sdk._apiToken;
+  if (!token) throw new Error(TOKEN_MISSING_ERROR);
+  const version = apiVersion || sdk._apiVersion;
+  return execute({ query, variables }, token, { apiVersion: version }).then(logWarnings);
+}
+
+module.exports = function itemsApi(sdk) {
+  return {
+    async createItem({ boardId, name, columnValues }, apiVersion) {
+      const query = `mutation ($boardId: Int!, $name: String!, $columnValues: JSON) {\n  create_item(board_id: $boardId, item_name: $name, column_values: $columnValues) { id name }\n}`;
+      const variables = { boardId, name, columnValues };
+      const result = await callExecute(sdk, query, variables, apiVersion);
+      return result.data.create_item;
+    },
+
+    async getItem({ itemId }, apiVersion) {
+      const query = `query ($itemId: Int!) {\n  items(ids: [$itemId]) { id name }\n}`;
+      const variables = { itemId };
+      const result = await callExecute(sdk, query, variables, apiVersion);
+      return result.data.items[0];
+    },
+
+    async archiveItem({ itemId }, apiVersion) {
+      const query = `mutation ($itemId: Int!) {\n  archive_item(item_id: $itemId) { id state }\n}`;
+      const variables = { itemId };
+      const result = await callExecute(sdk, query, variables, apiVersion);
+      return result.data.archive_item;
+    },
+
+    async listBoardItems({ boardId, limit = 25, cursor, queryParams }, apiVersion) {
+      let query;
+      let variables;
+      if (cursor && limit === undefined && !queryParams) {
+        query = `query ($boardId: Int!, $cursor: String!) {\n  boards(ids: [$boardId]) {\n    next_items_page(cursor: $cursor) {\n      cursor\n      items { id name }\n    }\n  }\n}`;
+        variables = { boardId, cursor };
+      } else {
+        query = `query ($boardId: Int!, $limit: Int, $cursor: String, $queryParams: JSON) {\n  boards(ids: [$boardId]) {\n    items_page(limit: $limit, cursor: $cursor, query_params: $queryParams) {\n      cursor\n      items { id name }\n    }\n  }\n}`;
+        variables = { boardId, limit, cursor, queryParams };
+      }
+      const result = await callExecute(sdk, query, variables, apiVersion);
+      const board = result.data.boards[0];
+      const page = board.items_page || board.next_items_page;
+      return {
+        items: page.items,
+        pageInfo: { limit, cursor: page.cursor || null, hasNextPage: Boolean(page.cursor) }
+      };
+    }
+  };
+};

--- a/src/boards-sdk/types.ts
+++ b/src/boards-sdk/types.ts
@@ -1,0 +1,71 @@
+/** Board visibility */
+export type BoardKind = "public" | "private" | "share";
+
+/** Filter operator applied between rules */
+export type ItemsQueryOperator = "and" | "or";
+
+/** Rule-level operator (API doc: any_of, between, contains_text, …) */
+export type ItemsQueryRuleOperator =
+  | "any_of"
+  | "not_any_of"
+  | "between"
+  | "eq"
+  | "neq"
+  | "is_empty"
+  | "is_not_empty"
+  | "contains_text"
+  | "not_contains_text";
+
+/** One rule inside query_params.rules */
+export interface ItemsQueryRule {
+  columnId: string;
+  compareValue?: (string | number | null)[];
+  compareAttribute?: string;
+  operator?: ItemsQueryRuleOperator;
+}
+
+/** Full query_params object (see https://developer.monday.com/api-reference/reference/items-page) */
+export interface ItemsQuery {
+  rules: ItemsQueryRule[];
+  operator?: ItemsQueryOperator;
+  orderBy?: { columnId: string; direction?: "asc" | "desc" }[];
+}
+
+/** Pagination wrapper used by listBoardItems */
+export interface Paginated<T> {
+  items: T[];
+  pageInfo: { limit: number; cursor: string | null; hasNextPage: boolean };
+}
+
+export interface ColumnValues {
+  [columnId: string]: unknown;
+}
+
+export interface Board {
+  id: number;
+  [key: string]: unknown;
+}
+
+export interface Item {
+  id: number;
+  [key: string]: unknown;
+}
+
+export interface BoardsApi {
+  createBoard(args: { name: string; kind?: BoardKind }, apiVersion?: string): Promise<Board>;
+  getBoard(args: { boardId: number }, apiVersion?: string): Promise<Board>;
+  archiveBoard(args: { boardId: number }, apiVersion?: string): Promise<{ id: number; state: string }>;
+}
+
+export interface ItemsApi {
+  createItem(
+    args: { boardId: number; name: string; columnValues?: ColumnValues },
+    apiVersion?: string
+  ): Promise<Item>;
+  getItem(args: { itemId: number }, apiVersion?: string): Promise<Item>;
+  archiveItem(args: { itemId: number }, apiVersion?: string): Promise<{ id: number; state: string }>;
+  listBoardItems(
+    args: { boardId: number; limit?: number; cursor?: string; queryParams?: ItemsQuery },
+    apiVersion?: string
+  ): Promise<Paginated<Item>>;
+}

--- a/src/client.js
+++ b/src/client.js
@@ -4,6 +4,8 @@ const { convertToArrayIfNeeded } = require("./helpers");
 const { initScrollHelperIfNeeded } = require("./helpers/ui-helpers");
 const { initBackgroundTracking } = require("./services/background-tracking-service");
 const { logWarnings } = require("./helpers/monday-api-helpers");
+const createBoardsApi = require("./boards-sdk/boards-api");
+const createItemsApi = require("./boards-sdk/items-api");
 
 const EMPTY_ARRAY = [];
 
@@ -41,6 +43,9 @@ class MondayClientSdk {
         deleteItem: this.deleteStorageInstanceItem.bind(this)
       }
     };
+
+    this.boards = createBoardsApi(this);
+    this.items = createItemsApi(this);
 
     window.addEventListener("message", this._receiveMessage, false);
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,8 @@
 const { logWarnings } = require("./helpers/monday-api-helpers");
 const mondayApiClient = require("./monday-api-client");
 const { oauthToken } = require("./services/oauth-service.js");
+const createBoardsApi = require("./boards-sdk/boards-api");
+const createItemsApi = require("./boards-sdk/items-api");
 
 const TOKEN_MISSING_ERROR = "Should send 'token' as an option or call mondaySdk.setToken(TOKEN)";
 
@@ -12,6 +14,9 @@ class MondayServerSdk {
     this.setToken = this.setToken.bind(this);
     this.setApiVersion = this.setApiVersion.bind(this);
     this.api = this.api.bind(this);
+
+    this.boards = createBoardsApi(this);
+    this.items = createItemsApi(this);
   }
 
   setToken(token) {

--- a/ts-tests/boards-sdk.test.ts
+++ b/ts-tests/boards-sdk.test.ts
@@ -1,0 +1,11 @@
+import mondaySdk from "../types";
+
+const monday = mondaySdk({ token: "token" });
+
+monday.boards.createBoard({ name: "b" }).then(res => {
+  const id: number = res.id;
+});
+
+monday.items.listBoardItems({ boardId: 1 }).then(res => {
+  const next: string | null = res.pageInfo.cursor;
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,8 @@
     },
     "files": [
         "types/index.d.ts",
-        "ts-tests/monday-sdk-js-module.test.ts"
+        "src/boards-sdk/types.ts",
+        "ts-tests/monday-sdk-js-module.test.ts",
+        "ts-tests/boards-sdk.test.ts"
     ]
 }

--- a/types/client-sdk.interface.ts
+++ b/types/client-sdk.interface.ts
@@ -1,5 +1,9 @@
 import { ClientData } from './client-data.interface';
 import { ClientExecute } from './client-execute.interface';
 import { ClientApi } from './client-api.interface';
+import { BoardsApi, ItemsApi } from '../src/boards-sdk/types';
 
-export type MondayClientSdk = ClientData & ClientExecute & ClientApi;
+export type MondayClientSdk = ClientData & ClientExecute & ClientApi & {
+  boards: BoardsApi;
+  items: ItemsApi;
+};

--- a/types/server-sdk.interface.ts
+++ b/types/server-sdk.interface.ts
@@ -1,4 +1,5 @@
 import { APIOptions } from './client-api.interface';
+import { BoardsApi, ItemsApi } from '../src/boards-sdk/types';
 
 export interface MondayServerSdk {
     setToken(token: string): void;
@@ -8,4 +9,7 @@ export interface MondayServerSdk {
     api<T = any>(query: string, options?: APIOptions): Promise<T>;
 
     oauthToken(code: string, clientId: string, clientSecret: string): Promise<any>;
+
+    boards: BoardsApi;
+    items: ItemsApi;
 }


### PR DESCRIPTION
## Summary
- expose a new Boards/Items API in both client and server SDKs
- implement board and item GraphQL wrappers
- document query types and pagination helpers
- update TypeScript interfaces and compiler config
- add unit tests for new API modules
- document board-item usage in README

## Testing
- `yarn lint` *(fails: package isn't in lockfile)*
- `yarn style-check` *(fails: package isn't in lockfile)*
- `yarn compile-types` *(fails: package isn't in lockfile)*
- `yarn test` *(fails: package isn't in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684a5c9733b48332829d04b753508a6b