### PR TITLE
Fix local API rejection for errors arrays

### DIFF
--- a/src/client-test.js
+++ b/src/client-test.js
@@ -197,4 +197,29 @@ describe("Monday Client Test API - Returning data", () => {
     clock.tick(5);
     window.removeEventListener("message", onPostMessage, false);
   });
+
+  it("API should reject the promise, when host raises an event with errors array", done => {
+    const clientId = "clientId";
+    const errors = [{ message: "First API error" }, { message: "Second API error" }];
+    function onPostMessage(event) {
+      const { requestId, method, type } = event.data;
+      if (method === "api" && !event.data.errors) {
+        window.postMessage({ requestId, method, type, errors }, "*");
+        //because in tests we don't have 2 different window object (parent and iframe) they are exchanging in the same
+        //events space, so here we need to stop the initial SDK event propogation to not allow SDK to react to it's own event
+        event.stopImmediatePropagation();
+      }
+    }
+    window.addEventListener("message", onPostMessage, false);
+
+    const mondayClient = initMondaySdk({ clientId });
+    mondayClient.api("query").catch(err => {
+      expect(err).to.be.ok;
+      expect(err.message).to.be.equal("First API error, Second API error");
+      expect(err.errors).to.be.equal(errors);
+      done();
+    });
+    clock.tick(5);
+    window.removeEventListener("message", onPostMessage, false);
+  });
 });

--- a/src/client.js
+++ b/src/client.js
@@ -7,6 +7,13 @@ const { logWarnings } = require("./helpers/monday-api-helpers");
 
 const EMPTY_ARRAY = [];
 
+function getErrorMessage(data) {
+  if (data.errorMessage) return data.errorMessage;
+  if (!Array.isArray(data.errors) || data.errors.length === 0) return null;
+
+  return data.errors.map(error => (error && error.message ? error.message : error)).join(", ");
+}
+
 const STORAGE_SEGMENT_KINDS = {
   GLOBAL: "v2",
   INSTANCE: "instance"
@@ -196,9 +203,11 @@ class MondayClientSdk {
       window.parent.postMessage({ method, args, requestId, clientId, version }, "*");
       const removeListener = this._addListener(requestId, data => {
         removeListener();
-        if (data.errorMessage) {
-          const error = new Error(data.errorMessage);
+        const errorMessage = getErrorMessage(data);
+        if (errorMessage) {
+          const error = new Error(errorMessage);
           error.data = data.data;
+          error.errors = data.errors;
           reject(error);
         } else {
           resolve(data);


### PR DESCRIPTION
Summary:
- reject local API bridge responses that contain a non-empty `errors` array
- preserve the raw `errors` array on the thrown error for callers that inspect it
- add a regression test for host responses that return GraphQL-style errors without `errorMessage`

Verification:
- `npx mocha ./src/client-test.js`
- `npm test -- --runInBand`
- `npx eslint ./src`
- `npx prettier --check "src/**/*.js"`
- `npm run compile-types`
- `git diff --check`
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`

Notes:
- `npm run lint` and `npm run style-check` fail on my Windows shell because the single-quoted glob patterns are passed literally, so I ran the equivalent direct `npx` checks above.
- The build itself passes with the legacy OpenSSL provider flag needed by webpack 4 on my local Node version. I did not include the regenerated `dist/main.js` because the current bundle appears stale versus `master` and the rebuild picks up unrelated drift beyond this fix.

This was implemented with Codex assistance, with the patch kept focused and manually reviewed before sending.